### PR TITLE
Make configuring CORS headers more robust

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,10 +7,12 @@ listenAddress: localhost:8050
 authorizationServiceUrl: http://localhost:8000/atlas/api/v1/authorize
 
 cors:
-  allowedOrigins: []
-  allowedMethods: []
-  allowedHeaders: []
-  allowCredentials: true
+  # allowedOrigins: ["http://www.test.nl"]
+  # allowedMethods: ["GET"]
+  # allowedHeaders: []
+  # allowCredentials: true
+  # allowPrivateNetwork: true
+  # debugLogging: false
 
 paths:
   - path: /api/ows

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ type Cors struct {
 	AllowedHeaders      []string `yaml:"allowedHeaders"`
 	AllowCredentials    bool     `yaml:"allowCredentials"`
 	AllowPrivateNetwork bool     `yaml:"allowPrivateNetwork"`
+	DebugLogging        bool     `yaml:"debugLogging"`
 }
 
 type Config struct {


### PR DESCRIPTION
- Pass all OPTIONS requests to the CORS library.
- By default only https://filter-proxy.local is allowed and configuration of every CORS property is optional.
- Add the option to configure CORS debugging.
