### PR TITLE
feat: add username to possible auth header

### DIFF
--- a/cmd/filter-proxy/main.go
+++ b/cmd/filter-proxy/main.go
@@ -33,6 +33,7 @@ type ClaimsWithGroups struct {
 type AuthorizationResponse struct {
 	Result         bool   `json:"result"`
 	ResponseFilter string `json:"response_filter"`
+	Username       string `json:"username"`
 }
 
 func main() {
@@ -69,7 +70,7 @@ func main() {
 				r.URL.Scheme = backendBaseUrl.Scheme
 
 				for headerKey, headerValue := range backend.Auth.Header {
-					parsedHeaderValue := utils.EnvSubst(headerValue)
+					parsedHeaderValue := utils.EnvSubst(headerValue, nil)
 					r.Header.Set(headerKey, parsedHeaderValue)
 				}
 
@@ -246,12 +247,14 @@ func main() {
 				transport := &http.Transport{TLSClientConfig: tlsConfig}
 
 				if backend.Auth.Basic.Username != "" && backend.Auth.Basic.Password != "" {
-					parsedPassword := utils.EnvSubst(backend.Auth.Basic.Password)
+					parsedPassword := utils.EnvSubst(backend.Auth.Basic.Password, nil)
 					backendRequest.SetBasicAuth(backend.Auth.Basic.Username, parsedPassword)
 				}
 
 				for headerKey, headerValue := range backend.Auth.Header {
-					parsedHeaderValue := utils.EnvSubst(headerValue)
+					parsedHeaderValue := utils.EnvSubst(headerValue, map[string]string{
+						"REQUEST_USERNAME": authorizationResponse.Username,
+					})
 					backendRequest.Header.Set(headerKey, parsedHeaderValue)
 				}
 


### PR DESCRIPTION
This change allows system administrators to pass an additional header to the backend containing the username of the requester.

```
backends:
  haal-centraal-brp:
    type: REST
    baseUrl: http://localhost:8051/api/brp/v1
    auth:
      header:
        X-Username: ${REQUEST_USERNAME}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Header templates can now include the authenticated username when forwarding to backends.
  * Configuration substitution supports per-request overrides for dynamic values.
  * Passthrough paths continue to behave unchanged (no override supplied).
  * Unknown substitution variables now remain in-place instead of being emptied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->